### PR TITLE
Feature: desktop horizontal pane resizing via divider

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -373,7 +373,6 @@ createApp({
 
     initializeLayout() {
       const container = document.querySelector(".editor-container");
-      if (!container) return
       this.containerWidth = container.offsetWidth;
       this.maxWidth = this.containerWidth - this.minWidth;
 

--- a/public/app.js
+++ b/public/app.js
@@ -373,6 +373,7 @@ createApp({
 
     initializeLayout() {
       const container = document.querySelector(".editor-container");
+      if (!container) return
       this.containerWidth = container.offsetWidth;
       this.maxWidth = this.containerWidth - this.minWidth;
 
@@ -387,6 +388,71 @@ createApp({
         editorGroup.style.width = this.editorWidth;
         preview.style.width = this.previewWidth;
       }
+    },
+
+    startResize(event) {
+      event.preventDefault();
+      this.isDragging = true;
+
+      // Get clientX from either mouse or touch event
+      this.startX = event.clientX || (event.touches && event.touches[0].clientX);
+
+      const editorGroup = document.querySelector(".editor-group");
+      this.startWidth = editorGroup.offsetWidth;
+
+      this.toggleIframe("none")
+
+      document.body.classList.add('resizing');
+
+      document.addEventListener('mousemove', this.onMouseMove);
+      document.addEventListener('touchmove', this.onTouchMove, { passive: false });
+      document.addEventListener('mouseup', this.onMouseUp);
+      document.addEventListener('touchend', this.onTouchEnd);
+    },
+
+    onMouseMove(event) {
+      if (!this.isDragging) return;
+      this.processMove(event.clientX);
+    },
+
+    onTouchMove(event) {
+      if (!this.isDragging) return;
+
+      // Prevents scrolling during resize on touch devices
+      event.preventDefault();
+
+      if (event.touches && event.touches[0]) {
+        this.processMove(event.touches[0].clientX);
+      }
+    },
+
+    processMove(clientX) {
+      const deltaX = clientX - this.startX;
+      this.editorWidth = `${this.startWidth + deltaX}px`;
+      this.updateLayout();
+    },
+
+    onMouseUp() {
+      this.endResize();
+    },
+
+    onTouchEnd() {
+      this.endResize();
+    },
+
+    endResize() {
+      if (!this.isDragging) return;
+
+      this.isDragging = false;
+      document.body.classList.remove('resizing');
+
+      this.toggleIframe("auto")
+
+      // Remove both mouse and touch event listeners
+      document.removeEventListener('mousemove', this.onMouseMove);
+      document.removeEventListener('touchmove', this.onTouchMove);
+      document.removeEventListener('mouseup', this.onMouseUp);
+      document.removeEventListener('touchend', this.onTouchEnd);
     },
 
     updatePreview() {
@@ -541,5 +607,13 @@ createApp({
         alert("Failed to copy URL");
       }
     },
+
+    /**@param {"auto" | "none"} setting */
+    toggleIframe(setting) {
+      const iframe = document.getElementById("preview-frame");
+      if (!iframe) return
+      iframe.style.pointerEvents = setting;
+    },
+
   },
 }).mount("#app");

--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,13 @@
           </div>
         </div>
 
+        <!-- Resize handle -->
+        <div class="resize-handle" 
+          v-show="showEditor && showPreview" 
+          @mousedown="startResize"
+          @touchstart="startResize"
+        ></div>
+
         <div
           class="preview"
           :style="{ width: previewWidth }"

--- a/public/style.css
+++ b/public/style.css
@@ -289,6 +289,8 @@ textarea::placeholder {
   position: relative;
   z-index: 10;
   flex-shrink: 0;
+  transition: background 0.15s;
+  margin: 0 -2px;
 }
 
 .resize-handle::after {
@@ -300,7 +302,18 @@ textarea::placeholder {
   width: 2px;
   background: var(--border);
   transform: translateX(-50%);
-  transition: background-color 0.15s;
+  transition: background 0.15s;
+}
+
+.resize-handle:hover,
+.resize-handle:active {
+  background: var(--primary-light);
+}
+
+.resize-handle:hover::after,
+.resize-handle:active::after {
+  background: var(--primary);
+  width: 4px;
 }
 
 body.resizing {


### PR DESCRIPTION
Adds support for dragging the pane divider to resize the two main panes so that users can seamlessly test their bin with various sizes and iterate on the code without having to change window sizes. This also handles the onTouch for mobile devices if the device width is large enough (e.g. my galaxy fold 5)

This wasn't explicitly asked for but i try to do this every time i play with this app and thought it'd be a good idea. 

Feel free to make changes as you see fit

> Note: vertical resize will come in separate PR if i do it