### PR TITLE
Fix Monaco Editor initialization - editors now interactive and working

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -67,6 +67,7 @@ require(['vs/editor/editor.main'], function () {
           css: null,
           js: null,
         },
+        isDarkMode: false,
 
         // ==================== View State ====================
         showEditor: true,
@@ -172,10 +173,12 @@ require(['vs/editor/editor.main'], function () {
       this.initializeLayout();
       document.addEventListener("keydown", this.handleKeyboardShortcuts);
 
-      // Initialize Monaco editors
-      this.$nextTick(() => {
-        this.initializeMonacoEditors();
-      });
+      // Initialize Monaco editors - give it time to load
+      setTimeout(() => {
+        this.$nextTick(() => {
+          this.initializeMonacoEditors();
+        });
+      }, 100);
 
       // Listen for window resize to layout editors
       window.addEventListener("resize", () => {
@@ -196,7 +199,10 @@ require(['vs/editor/editor.main'], function () {
       // ==================== Monaco Editor Setup ====================
       initializeMonacoEditors() {
         const editorContainer = this.$refs.monacoEditor;
-        if (!editorContainer) return;
+        if (!editorContainer) {
+          console.error("Monaco editor container not found");
+          return;
+        }
 
         const theme = this.isDarkMode ? "vs-dark" : "vs";
 
@@ -209,7 +215,7 @@ require(['vs/editor/editor.main'], function () {
           scrollBeyondLastLine: false,
           wordWrap: "on",
           wrappingStrategy: "advanced",
-          automaticLayout: true,
+          automaticLayout: false, // We'll handle layout manually
           tabSize: 2,
           insertSpaces: true,
           formatOnPaste: true,
@@ -233,6 +239,15 @@ require(['vs/editor/editor.main'], function () {
           this.editors[tab.id].onDidChangeModelContent(() => {
             this[tab.id] = this.editors[tab.id].getValue();
           });
+        });
+
+        // Initial layout after creation
+        this.$nextTick(() => {
+          this.layoutEditors();
+          // Focus the active editor
+          if (this.editors[this.activeTab]) {
+            this.editors[this.activeTab].focus();
+          }
         });
       },
 

--- a/public/style.css
+++ b/public/style.css
@@ -244,6 +244,14 @@ nav {
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+/* Ensure Monaco editor is interactive */
+.monaco-editor {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 /* Override Monaco Editor default styles to match theme */


### PR DESCRIPTION
Fixed critical bug where Monaco editors were frozen and unresponsive.

## Issues Fixed:

1. **Missing reactive property**: `isDarkMode` was set in created() hook but not declared in data(), causing undefined reference errors

2. **Timing issue**: Monaco editors initialized too quickly before DOM was ready

3. **CSS positioning**: Monaco containers needed explicit right/bottom positioning and width/height enforcement

## Changes:

### app.js:
- Added `isDarkMode: false` to data() section (line 70)
- Changed `automaticLayout: false` and handle layout manually for better control
- Added 100ms delay before Monaco initialization to ensure DOM readiness
- Added console error logging if editor container not found
- Added explicit focus to active editor after initialization
- Added $nextTick() before layout call

### style.css:
- Added right: 0, bottom: 0 to .monaco-editor-container
- Added explicit width/height enforcement to .monaco-editor class
- Ensures Monaco is fully sized and interactive

## Result:

✅ Editors now load properly
✅ Typing works in all tabs (HTML, CSS, JS)
✅ Tab switching works correctly
✅ Editor is focused and ready to type on load
✅ Proper sizing and layout
✅ Theme detection works

Tested and working!