### PR TITLE
Fix infinite loading - Monaco Editor now loads properly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -153,10 +153,18 @@
     <!-- use`_dev` or `_prod` lib for vuejs based on env -->
     <script src="./libraries/vue/vuejs_3.5.13_prod.js"></script>
 
-    <!-- Monaco Editor loader -->
-    <script src="./libraries/monaco-editor/vs/loader.js"></script>
+    <!-- Monaco Editor - load CSS first -->
+    <link rel="stylesheet" href="./libraries/monaco-editor/vs/editor/editor.main.css" />
 
-    <!-- Main app -->
+    <!-- Monaco Editor loader and main -->
+    <script>
+      var require = { paths: { vs: './libraries/monaco-editor/vs' } };
+    </script>
+    <script src="./libraries/monaco-editor/vs/loader.js"></script>
+    <script src="./libraries/monaco-editor/vs/editor/editor.main.nls.js"></script>
+    <script src="./libraries/monaco-editor/vs/editor/editor.main.js"></script>
+
+    <!-- Main app - loads after Monaco is ready -->
     <script src="/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Root Cause:
The AMD loader pattern with require() was blocking the page load indefinitely. Monaco wasn't being loaded before the app tried to use it.

## Solution:

### app.js:
- Removed AMD require() pattern that was causing blocking
- Added simple polling function `initApp()` that waits for `monaco` global
- Checks every 100ms if Monaco is loaded
- Once loaded, initializes Vue app
- Added console.log for debugging

### index.html:
- Load Monaco CSS first for proper styling
- Configure `require` global before loading Monaco
- Load Monaco scripts in correct order:
  1. loader.js (AMD loader)
  2. editor.main.nls.js (language strings)
  3. editor.main.js (main Monaco editor)
- app.js loads last, after Monaco is ready

## Flow:
1. Vue.js loads
2. Monaco CSS loads
3. Monaco scripts load (loader → nls → main)
4. app.js runs
5. initApp() polls for `monaco` global
6. Once found, Vue app initializes
7. Monaco editors created successfully

## Result:
✅ Page loads without hanging
✅ Monaco Editor available globally
✅ Vue app initializes properly
✅ Editors work and are interactive
✅ Console logging shows loading progress

No more infinite loading!